### PR TITLE
Fixed X-Forwarded-Proto for pub API v2 and group ID API 

### DIFF
--- a/puppet/modules/shibboleth_nginx/templates/etc/nginx/sites-available/default
+++ b/puppet/modules/shibboleth_nginx/templates/etc/nginx/sites-available/default
@@ -92,7 +92,14 @@ server {
         limit_req   zone=api_default  burst=40;
         proxy_read_timeout 120;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        set $proto 'http';
+        if ($scheme = 'https') {
+           set $proto 'https';
+        }
+        if ($http_x_forwarded_proto = 'https') {
+           set $proto 'https';
+        }
+        proxy_set_header X-Forwarded-Proto $proto;
         proxy_set_header Host $http_host;
         proxy_pass http://<%= @api_ip_port %>/orcid-api-web$request_uri;
 
@@ -183,7 +190,14 @@ server {
 
         proxy_read_timeout 120;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        set $proto 'http';
+        if ($scheme = 'https') {
+           set $proto 'https';
+        }
+        if ($http_x_forwarded_proto = 'https') {
+           set $proto 'https';
+        }
+        proxy_set_header X-Forwarded-Proto $proto;
         proxy_set_header Host $http_host;
         proxy_pass http://<%= @pub_ip_port %>/orcid-pub-web$request_uri;
 


### PR DESCRIPTION
(when behin Rackspace load balancer).

https://trello.com/c/TkznpYRa/2646-all-calls-to-the-group-api-return-an-https-error-even-when-https-is-used

and

https://trello.com/c/nBcRjx9O/2649-2-0-calls-to-the-public-api-return-an-https-error-even-when-you-are-using-https