### PR TITLE
Txgh prod config fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,42 @@ Hint: For tomcat you need to modify your VM arguments to support https and new d
 
 # Running txgh
 
+##Create the txgh.yml configuration file
+
+**NOTE: Puppet will not run correctly without this file configured**
+
+1. Copy puppet/modules/orcid_txgh/example-txgh.yml in the same directory and name it txgh.yml
+        
+        cp puppet/modules/orcid_txgh/example-txgh.yml puppet/modules/orcid_txgh/txgh.yml
+
+2. Edit txgh.yml to add the credential information for your Github repo and Transifex project
+
+        vim puppet/modules/orcid_txgh/txgh.yml
+
+        txgh:
+            github:
+                repos:
+                   #full github repo name including username
+                   githubuser/repo-name:
+                        #your github username
+                        api_username: githubuser
+                        #github personal api token - see https://github.com/blog/1509-personal-api-tokens
+                        api_token: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+                        #get this from the project URL when logged into transifex web UI (project URL like: https://www.transifex.com/account-name/transifex-project-id)
+                        push_source_to: transifex-project-id
+            transifex:
+                projects:
+                   #transifex project id - same as push_source_to value above
+                   transifex-project-id:
+                        #tx.config file location 
+                        tx_config: "/home/orcid_txgh/txgh-master/config/tx.config"
+                        #transifex username
+                        api_username: transifexuser
+                        #transifex password - same as web UI password
+                        api_password: XXXXXXXXXXXXXXX
+                        #full github repo name including username - same as repo name in repos section above
+                        push_translations_to: githubuser/repo-name 
+
 ##Configure the TXGH server
 
 1. Run vagrant txgh
@@ -100,28 +136,8 @@ Hint: For tomcat you need to modify your VM arguments to support https and new d
         source_file = api_en.properties
         source_lang = en
         type = PROPERTIES
-tx.config file can also be generated automatically using the Transifex command line client. For more on formatting a tx.config file, see: http://docs.transifex.com/client/config/#txconfig
 
-
-4. Edit the txgh.yml file to include the information for your Github repo and Transifex project
-
-        vim txgh-master/config/txgh.yml
-
-        txgh:
-            github:
-               repos:
-                   ORCID/txgh_test:
-                        api_username: gituser
-                        api_token: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-                        push_source_to: txgh-test-2
-            transifex:
-                projects:
-                    txgh-test-2:
-                        tx_config: "/home/vagrant/txgh-master/config/tx.config"
-                        api_username: transifexuser
-                        api_password: XXXXXXXXXXXXXXX
-                        push_translations_to: ORCID/txgh_test 
-Note: For development purposes, you can use a [Github Personal API Token](https://github.com/blog/1509-personal-api-tokens); your Transifex API Password is the same as your Transifex web interface password.                                                    
+tx.config file can also be generated automatically using the Transifex command line client. For more on formatting a tx.config file, see: http://docs.transifex.com/client/config/#txconfig                                                    
 
 5. Start ngrok to expose localhost webhook port publicly (for local dev only)
 

--- a/README.md
+++ b/README.md
@@ -77,17 +77,87 @@ Hint: For tomcat you need to modify your VM arguments to support https and new d
 
 # Running txgh
 
+##Prerequisites
+1. Create a Transifex account https://www.transifex.com/signin
+2. Create a new Transifex project https://www.transifex.com/[account-name]/add/
+3. Install the Transifex command line client http://docs.transifex.com/tutorials/client/#1-initialize-a-transifex-project
+
+##(New Transifex projects only) Create the .tx/config file
+
+Transifex requires a per project configuration file to store the project's details and the file-to-resource mappings. This file is stored in .tx/config of your project's root directory. This file can either be created manually, or automatically using the Transifex client. To create .tx/config for a new project using the Transifex client:
+
+1. Clone the repository that contains the source language properties files
+
+        git clone [repo]
+
+3. Change directories into the repo that you just cloned
+
+        cd ~/git/repo-name
+
+4. Initialize the repo as a TXGH project, per http://docs.transifex.com/tutorials/client/#1-initialize-a-transifex-project
+
+        tx init
+
+5. When ```Transifex instance [https://www.transifex.com]:``` is displayed, press ```Enter``` This creates an empty .tx/config file.
+
+6. Add each resource type to the .tx/config file, per http://docs.transifex.com/client/set/
+
+        tx set --auto-local -r txgh-test-2.api 'api_<lang>.properties' --source-lang en --type PROPERTIES --source-file api_en.properties --execute
+
+        tx set --auto-local -r txgh-test-2.email 'email_<lang>.properties' --source-lang en --type PROPERTIES --source-file email_en.properties --execute
+
+        tx set --auto-local -r txgh-test-2.javascript 'javascript_<lang>.properties' --source-lang en --type PROPERTIES --source-file javascript_en.properties --execute
+
+        tx set --auto-local -r txgh-test-2.messages 'messages_<lang>.properties' --source-lang en --type PROPERTIES --source-file messages_en.properties --execute
+
+7. Verify that the resources have been added to .tx/config
+
+        cat .tx/config
+
+        [main]
+        host = https://www.transifex.com
+
+        [txgh-test-2.api]
+        file_filter = api_<lang>.properties
+        source_file = api_en.properties
+        source_lang = en
+        type = PROPERTIES
+
+        [txgh-test-2.messages]
+        file_filter = messages_<lang>.properties
+        source_file = messages_en.properties
+        source_lang = en
+        type = PROPERTIES
+
+        [txgh-test-2.email]
+        file_filter = email_<lang>.properties
+        source_file = email_en.properties
+        source_lang = en
+        type = PROPERTIES
+
+        [txgh-test-2.javascript]
+        file_filter = javascript_<lang>.properties
+        source_file = javascript_en.properties
+        source_lang = en
+        type = PROPERTIES
+
+8. Commit and push the changes to the remote repository
+9. Edit the ```github_repo``` variable in ```puppet/manifests/txgh_default.pp``` to include the name of your repo.
+        
+        github_repo => 'ORCID/txgh_test',
+        
+
 ##Create the txgh.yml configuration file
 
 **NOTE: Puppet will not run correctly without this file configured**
 
-1. Copy puppet/modules/orcid_txgh/example-txgh.yml in the same directory and name it txgh.yml
+1. Copy ```puppet/modules/orcid_txgh/example-txgh.yml``` in the same directory and name it ```txgh.yml```
         
-        cp puppet/modules/orcid_txgh/example-txgh.yml puppet/modules/orcid_txgh/txgh.yml
+        cp puppet/modules/orcid_txgh/files/example-txgh.yml puppet/modules/orcid_txgh/files/txgh.yml
 
 2. Edit txgh.yml to add the credential information for your Github repo and Transifex project
 
-        vim puppet/modules/orcid_txgh/txgh.yml
+        vim puppet/modules/orcid_txgh/files/txgh.yml
 
         txgh:
             github:
@@ -113,7 +183,7 @@ Hint: For tomcat you need to modify your VM arguments to support https and new d
                         #full github repo name including username - same as repo name in repos section above
                         push_translations_to: githubuser/repo-name 
 
-##Configure the TXGH server
+##Start the TXGH server
 
 1. Run vagrant txgh
 
@@ -121,34 +191,18 @@ Hint: For tomcat you need to modify your VM arguments to support https and new d
 
 2. SSH to txgh machine
 
-        vagrant ssh txgh
+        vagrant ssh txgh         
 
-3. Edit the tx.config file to include the information about your Transifex project resources
-
-        vim txgh-master/config/tx.config
-
-        [main]
-        host = https://www.transifex.com
-
-        #Create one such section per resource
-        [txgh-test-2.api]
-        file_filter = api_<lang>.properties
-        source_file = api_en.properties
-        source_lang = en
-        type = PROPERTIES
-
-tx.config file can also be generated automatically using the Transifex command line client. For more on formatting a tx.config file, see: http://docs.transifex.com/client/config/#txconfig                                                    
-
-5. Start ngrok to expose localhost webhook port publicly (for local dev only)
+3. Start ngrok to expose localhost webhook port publicly (for local dev only)
 
         ./ngrok http 9292
 This will generate an ngrok URL, which will be used to configure Github and Transifex webhooks
 
         Forwarding      https://ebefeec3.ngrok.io -> localhost:9292
 
-6. Start the txgh server
+4. Start the txgh server
 
-        cd txgh-master
+        cd /home/orcid_txgh/txgh-master
         rackup -o 0.0.0.0
 
 ##Configure Github webhook

--- a/puppet/manifests/txgh_default.pp
+++ b/puppet/manifests/txgh_default.pp
@@ -7,3 +7,19 @@ include bootstrap
 include orcid_base::baseapps
 include orcid_base::common_libs
 include orcid_txgh
+
+user { "orcid_txgh":
+  ensure  => present,
+  uid  => '7012',
+  shell  => '/bin/bash',
+  home  => '/home/orcid_txgh',
+  managehome => true,
+  password => 'd9hliCDStS+VyAmWAZuCu4xnSRDsHIEE/Ve3/BzcToxp4tJDMxcn+CoJxtQl2+MZS1Lhp+jTLtqviDP1NbqpX2IOE9xapZHVUi8AWOjD',
+}
+
+file { "/home/orcid_txgh":
+  ensure  => directory,
+  owner => orcid_txgh,
+  group => orcid_txgh,
+  require => User["orcid_txgh"],
+}

--- a/puppet/manifests/txgh_default.pp
+++ b/puppet/manifests/txgh_default.pp
@@ -6,7 +6,14 @@ Exec {
 include bootstrap
 include orcid_base::baseapps
 include orcid_base::common_libs
-include orcid_txgh
+#include orcid_txgh
+
+class {
+  orcid_txgh:
+    github_repo => 'ORCID/txgh_test',
+}
+
+
 
 user { "orcid_txgh":
   ensure  => present,

--- a/puppet/modules/orcid_txgh/.gitignore
+++ b/puppet/modules/orcid_txgh/.gitignore
@@ -1,0 +1,1 @@
+txgh.yml

--- a/puppet/modules/orcid_txgh/files/download_tx_config.erb
+++ b/puppet/modules/orcid_txgh/files/download_tx_config.erb
@@ -1,0 +1,1 @@
+wget -O https://raw.githubusercontent.com/<%= @github_repo -%>/master/i18n/.tx/config

--- a/puppet/modules/orcid_txgh/files/example-txgh.yml
+++ b/puppet/modules/orcid_txgh/files/example-txgh.yml
@@ -1,0 +1,23 @@
+txgh:
+    github:
+        repos:
+           #full github repo name including username
+           githubuser/repo-name:
+                #your github username
+                api_username: githubuser
+                #github personal api token - see https://github.com/blog/1509-personal-api-tokens
+                api_token: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+                #get this from the project URL when logged into transifex web UI (project URL like: https://www.transifex.com/account-name/transifex-project-id)
+                push_source_to: transifex-project-id
+    transifex:
+        projects:
+           #transifex project id - same as push_source_to value above
+           transifex-project-id:
+                #tx.config file location 
+                tx_config: "/home/orcid_txgh/txgh-master/config/tx.config"
+                #transifex username
+                api_username: transifexuser
+                #transifex password - same as web UI password
+                api_password: XXXXXXXXXXXXXXX
+                #full github repo name including username - same as repo name in repos section above
+                push_translations_to: githubuser/repo-name 

--- a/puppet/modules/orcid_txgh/manifests/init.pp
+++ b/puppet/modules/orcid_txgh/manifests/init.pp
@@ -14,25 +14,27 @@ class orcid_txgh {
   exec { "ruby":
     environment => [ "DEBIAN_FRONTEND=noninteractive" ], # same as export DEBIAN_FRONTEND=noninteractive
     command => template("orcid_txgh/scripts/install_ruby.erb"),
-    require => Package["wget"]
+    require => Package["wget"],
+    timeout => 1800,
   }
 
-  $txgh_loc = '/home/$USER'
+  $txgh_loc = '/home/orcid_txgh'
   $txgh_rb = "txgh-master"
   $txgh_zip = "${txgh_rb}.zip"
 
 
   # download the txgh-master zip
-  file { "/home/$USER/$txgh_zip":
-    path   => "/home/$USER/$txgh_zip",
+  file { "/home/orcid_txgh/$txgh_zip":
+    path   => "$txgh_loc/$txgh_zip",
     source  => "puppet:///modules/orcid_txgh/$txgh_zip",
+    require => Exec["ruby"]
   }
 
   # unzip txgh-master zip at the desired location
   exec { "unzip $txgh_zip":
-    command => "unzip $txgh_loc/$txgh_zip",
-    creates => "/$txgh_loc/$txgh_rb",
-    require => Exec["ruby"]
+    command => "sudo unzip $txgh_loc/$txgh_zip -d $txgh_loc",
+    creates => "$txgh_loc/$txgh_rb",
+    require => File["/home/orcid_txgh/$txgh_zip"]
   }
 
   exec { "bundler":
@@ -42,22 +44,24 @@ class orcid_txgh {
     require => Exec["unzip $txgh_zip"]
   }
 
-  $ngrok_loc = '/home/$USER'
+  $ngrok_loc = '/home/orcid_txgh'
   $ngrok_bin = "ngrok-stable-linux-amd64"
   $ngrok_zip = "${ngrok_bin}.zip"
 
 
   # download the ngrok zip
-  file { "/home/$USER/$ngrok_zip":
-    path   => "/home/$USER/$ngrok_zip",
+  file { "/home/orcid_txgh/$ngrok_zip":
+    path   => "/home/orcid_txgh/$ngrok_zip",
     source  => "puppet:///modules/orcid_txgh/$ngrok_zip",
   }
 
   # unzip ngrok zip at the desired location
   exec { "unzip $ngrok_zip":
-    command => "unzip $ngrok_loc/$ngrok_zip",
+    command => "sudo unzip $ngrok_loc/$ngrok_zip",
     creates => "/$ngrok_loc/$ngrok_bin",
     require => Exec["bundler"]
   }
+
+
 
 }

--- a/puppet/modules/orcid_txgh/manifests/init.pp
+++ b/puppet/modules/orcid_txgh/manifests/init.pp
@@ -37,11 +37,18 @@ class orcid_txgh {
     require => File["/home/orcid_txgh/$txgh_zip"]
   }
 
+  # download the txgh.yml configuration file
+  file { "$txgh_loc/$txgh_rb/config/txgh.yml":
+    path   => "$txgh_loc/$txgh_rb/config/txgh.yml",
+    source  => "puppet:///modules/orcid_txgh/txgh.yml",
+    require => Exec["unzip $txgh_zip"]
+  }
+
   exec { "bundler":
     environment => [ "DEBIAN_FRONTEND=noninteractive" ], # same as export DEBIAN_FRONTEND=noninteractive
     provider => shell,
     command => template("orcid_txgh/scripts/install_bundler.erb"),
-    require => Exec["unzip $txgh_zip"]
+    require => File["$txgh_loc/$txgh_rb/config/txgh.yml"]
   }
 
   $ngrok_loc = '/home/orcid_txgh'

--- a/puppet/modules/orcid_txgh/templates/scripts/download_tx_config.erb
+++ b/puppet/modules/orcid_txgh/templates/scripts/download_tx_config.erb
@@ -1,0 +1,1 @@
+wget https://raw.githubusercontent.com/<%= @github_repo -%>/master/i18n/.tx/config -O /home/orcid_txgh/txgh-master/config/tx.config

--- a/puppet/modules/orcid_txgh/templates/scripts/download_tx_config.erb
+++ b/puppet/modules/orcid_txgh/templates/scripts/download_tx_config.erb
@@ -1,1 +1,1 @@
-wget https://raw.githubusercontent.com/<%= @github_repo -%>/master/i18n/.tx/config -O /home/orcid_txgh/txgh-master/config/tx.config
+wget https://raw.githubusercontent.com/<%= @github_repo -%>/master/.tx/config -O /home/orcid_txgh/txgh-master/config/tx.config

--- a/puppet/modules/orcid_txgh/templates/scripts/install_bundler.erb
+++ b/puppet/modules/orcid_txgh/templates/scripts/install_bundler.erb
@@ -1,3 +1,3 @@
-cd txgh-master
+cd /home/orcid_txgh/txgh-master
 sudo gem install bundler
 bundle install

--- a/puppet/modules/orcid_txgh/templates/scripts/install_ruby.erb
+++ b/puppet/modules/orcid_txgh/templates/scripts/install_ruby.erb
@@ -1,5 +1,6 @@
 wget http://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.5.tar.gz 
 tar -xvzf ruby-2.1.5.tar.gz
+chown -R root:root ruby-2.1.5 
 cd ruby-2.1.5/
 ./configure --prefix=/usr/local
 make


### PR DESCRIPTION
Adds orcid_txgh user, fake example-txgh.yml config file and gitigore for txgh.yml. Puppet dependencies will fail if txgh.yml is not created in orcid_txgh/files before starting.