### PR TITLE
add communities back to nginx and redirect to about

### DIFF
--- a/puppet/manifests/nginx_shibboleth_default.pp
+++ b/puppet/manifests/nginx_shibboleth_default.pp
@@ -12,6 +12,7 @@ class {
    shibboleth_nginx:
       env => 'dev',
       api_ip_port => "127.0.0.1:8080",
+      communities_ip_port => "127.0.0.1:7777",
       about_ip_port => "127.0.0.1:8888",
       members_ip_port => "127.0.0.1:9999",
       pub_ip_port => "127.0.0.1:8080",

--- a/puppet/modules/shibboleth_nginx/manifests/init.pp
+++ b/puppet/modules/shibboleth_nginx/manifests/init.pp
@@ -8,6 +8,7 @@ class shibboleth_nginx (
     $about_ip_port,
     $api_ip_port,
     $members_ip_port,
+    $communities_ip_port,
     $pub_ip_port,
     $registry_ip_port,
     $include_test_idps = false,) {
@@ -50,6 +51,7 @@ class shibboleth_nginx (
             ssl_certificate_key => $ssl_certificate_key,
             about_ip_port => $about_ip_port,
             api_ip_port => $api_ip_port,
+            communities_ip_port => $communities_ip_port,
             members_ip_port => $members_ip_port, 
             pub_ip_port => $pub_ip_port,
             registry_ip_port => $registry_ip_port,

--- a/puppet/modules/shibboleth_nginx/manifests/nginx.pp
+++ b/puppet/modules/shibboleth_nginx/manifests/nginx.pp
@@ -6,6 +6,7 @@ class shibboleth_nginx::nginx (
     $about_ip_port,
     $api_ip_port,
     $members_ip_port,
+    $communities_ip_port,
     $pub_ip_port,
     $registry_ip_port, ) {
 

--- a/puppet/modules/shibboleth_nginx/templates/etc/nginx/sites-available/default
+++ b/puppet/modules/shibboleth_nginx/templates/etc/nginx/sites-available/default
@@ -111,6 +111,39 @@ server {
 server {
     listen 80;
     listen 443 ssl;
+
+    server_name communities.<%= @host_name %>;
+    access_log  off;
+
+    keepalive_timeout 5;
+
+    client_max_body_size 200m;
+
+    location / {
+        client_max_body_size 200m;
+        limit_req   zone=web  burst=64;
+
+        proxy_read_timeout 120;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        set $proto 'http';
+        if ($scheme = 'https') {
+           set $proto 'https';
+        }
+        if ($http_x_forwarded_proto = 'https') {
+           set $proto 'https';
+        }
+        proxy_set_header X-Forwarded-Proto $proto;
+
+        proxy_set_header Host $http_host;
+        proxy_pass http://<%= @communities_ip_port %>/;
+    }
+
+    return 301 $proto://<%= @host_name %>;
+}
+
+server {
+    listen 80;
+    listen 443 ssl;
     server_name members.<%= @host_name %>;
 
     access_log  off;

--- a/puppet/modules/shibboleth_nginx/templates/etc/nginx/sites-available/default
+++ b/puppet/modules/shibboleth_nginx/templates/etc/nginx/sites-available/default
@@ -119,26 +119,7 @@ server {
 
     client_max_body_size 200m;
 
-    location / {
-        client_max_body_size 200m;
-        limit_req   zone=web  burst=64;
-
-        proxy_read_timeout 120;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        set $proto 'http';
-        if ($scheme = 'https') {
-           set $proto 'https';
-        }
-        if ($http_x_forwarded_proto = 'https') {
-           set $proto 'https';
-        }
-        proxy_set_header X-Forwarded-Proto $proto;
-
-        proxy_set_header Host $http_host;
-        proxy_pass http://<%= @communities_ip_port %>/;
-    }
-
-    return 301 $proto://<%= @host_name %>;
+    return 301 $scheme://<%= @host_name %>;
 }
 
 server {


### PR DESCRIPTION
Redirect communities to about instead of just removing. Could possibly redirect to consortia communities pages in future.