### PR TITLE
Txgh autostart

### DIFF
--- a/puppet/modules/orcid_txgh/manifests/init.pp
+++ b/puppet/modules/orcid_txgh/manifests/init.pp
@@ -97,9 +97,32 @@ class orcid_txgh ($github_repo) {
     #require => Exec["bundler"]
   }
 
-  exec { "rackup":
-    command => "bash -l -c 'su - orcid_txgh && cd /home/orcid_txgh/txgh-master && nohup rackup -o 0.0.0.0 > $(date +%m-%d-%Y)_txgh.log&'",
+  #exec { "rackup":
+    #command => "bash -l -c 'su - orcid_txgh && cd /home/orcid_txgh/txgh-master && nohup rackup -o 0.0.0.0 > $(date +%m-%d-%Y)_txgh.log&'",
+    #require => Exec["bundler"]
+  #}
+
+  file { "/etc/init.d/txgh":
+    ensure => file,
+    mode  => '0755',
+    content => template('orcid_txgh/etc/init.d/txgh.erb'),
+    owner  => "root",
+    group  => "root",
     require => Exec["bundler"]
   }
+
+  file { [ "/etc/rc0.d/K20txgh", "/etc/rc1.d/K20txgh", "/etc/rc2.d/S20txgh",
+    "/etc/rc3.d/S20txgh", "/etc/rc4.d/S20txgh", "/etc/rc5.d/S20txgh", "/etc/rc6.d/K20txgh" ]:
+    ensure  => link,
+    target  => '/etc/init.d/txgh',
+    require => File["/etc/init.d/txgh"]
+  }
+
+  service { 'txgh':
+    ensure => 'running',
+    enable => 'true',
+    require => File["/etc/init.d/txgh"]
+  }
+
 
 }

--- a/puppet/modules/orcid_txgh/templates/etc/init.d/txgh.erb
+++ b/puppet/modules/orcid_txgh/templates/etc/init.d/txgh.erb
@@ -9,7 +9,9 @@
 # Short-Description: Start TXGH
 ### END INIT INFO
 
-PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games:/usr/local/rvm/bin
+#PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games:/usr/local/rvm/bin
+#PATH=/sbin:/bin:/usr/sbin:/usr/bin
+PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/usr/local/sbin
 
 . /lib/lsb/init-functions
 
@@ -57,5 +59,3 @@ case $1 in
                 exit 2
                 ;;
 esac
-                                                                                                                                                                  70,1          Bot
-

--- a/puppet/modules/orcid_txgh/templates/etc/init.d/txgh.erb
+++ b/puppet/modules/orcid_txgh/templates/etc/init.d/txgh.erb
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+### BEGIN INIT INFO
+# Provides:        txgh
+# Required-Start:  $network
+# Required-Stop:   $network
+# Default-Start:   2 3 4 5
+# Default-Stop:    1
+# Short-Description: Start TXGH
+### END INIT INFO
+
+PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games:/usr/local/rvm/bin
+
+. /lib/lsb/init-functions
+
+PRGDIR="<%= @txgh_loc %>/<%= @txgh_rb %>"
+EXECUTABLE="start_txgh.sh"
+
+case $1 in
+        start)
+                log_daemon_msg "Starting TXGH"
+                bash -l -c 'su - orcid_txgh && cd /home/orcid_txgh/txgh-master && nohup rackup -o 0.0.0.0 > $(date +%m-%d-%Y)_txgh.log&'
+                status=$?
+                log_end_msg $status
+                ;;
+        stop)
+                log_daemon_msg "Stopping TXGH"
+                exec "$PRGDIR"/"$EXECUTABLE" stop "$@"
+                log_end_msg $?
+                ;;
+        restart|force-reload)
+                $0 stop && sleep 2 && $0 start
+                ;;
+        try-restart)
+                if $0 status >/dev/null; then
+                        $0 restart
+                else
+                        exit 0
+                fi
+                ;;
+        reload)
+                exit 3
+                ;;
+        status)
+                PID=`pgrep -f txgh-master`
+                STATUS=$?
+                if [ $STATUS = 0 ]; then
+                        echo "TXGH is running: pid $PID"
+                        exit 0
+                else
+                        echo "TXGH is not running"
+                        exit 2
+                fi
+                ;;
+        *)
+                echo "Usage: $0 {start|stop|restart|try-restart|force-reload|status}"
+                exit 2
+                ;;
+esac
+                                                                                                                                                                  70,1          Bot
+


### PR DESCRIPTION
Use init.d to start TXGH. Logging needs to be fixed so that TXGH logs to file by default and logs are rotated at timed intervals. Will add on a separate PR.